### PR TITLE
Add github actions

### DIFF
--- a/.github/actions/python-deps/action.yml
+++ b/.github/actions/python-deps/action.yml
@@ -1,0 +1,20 @@
+name: "install-python-deps"
+description: |
+  # install-python-deps
+
+  Use to install pyproject.toml dependencies for use inside Github actions.
+  This is not used to install runtime dependencies for building the deploy
+  artifact. As such, dev dependencies are installed.
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  - uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+    with:
+      enable-cache: true
+  - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+    with:
+      python-version-file: "pyproject.toml"
+  - shell: bash
+    run: uv sync --dev --frozen

--- a/.github/actions/ts-deps/action.yml
+++ b/.github/actions/ts-deps/action.yml
@@ -14,13 +14,13 @@ runs:
     name: "Parse pnpm version from package.json"
     shell: bash
     run: |
-      version=$(cat package.json | jq .engines.pnpm)
+      version=$(jq -r .engines.pnpm package.json)
       echo "version=$version" >> "$GITHUB_OUTPUT"
   - id: node-version
     name: "Parse node version from pnpm-workspace.yaml"
     shell: bash
     run: |
-      version=$(cat pnpm-workspace.yaml | yq .useNodeVersion)
+      version=$(yq .useNodeVersion pnpm-workspace.yaml)
       echo "version=$version" >> "$GITHUB_OUTPUT"
   - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
     with:

--- a/.github/actions/ts-deps/action.yml
+++ b/.github/actions/ts-deps/action.yml
@@ -1,0 +1,34 @@
+name: "install-ts-deps"
+description: |
+  # install-ts-deps
+
+  Use to install package.json dependencies for use inside Github actions.
+  This is not used to install runtime dependencies for building the deploy
+  artifact. As such, dev dependencies are installed.
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  - id: pnpm-version
+    name: "Parse pnpm version from package.json"
+    shell: bash
+    run: |
+      version=$(cat package.json | jq .engines.pnpm)
+      echo "version=$version" >> "$GITHUB_OUTPUT"
+  - id: node-version
+    name: "Parse node version from pnpm-workspace.yaml"
+    shell: bash
+    run: |
+      version=$(cat pnpm-workspace.yaml | yq .useNodeVersion)
+      echo "version=$version" >> "$GITHUB_OUTPUT"
+  - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    with:
+      version: ${{ steps.pnpm-version.outputs.version }}
+      run_install: false
+  - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    with:
+      node-version: ${{ steps.node-version.outputs.version }}
+      cache: pnpm
+  - shell: bash
+    run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
     - uses: ./.github/actions/ts-deps
     - run: pnpm oxlint
     - run: pnpm biome check
-  lint-gha:
+  lint-github-actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
-    - run: uv run zizmor --min-severity=high .github
+    - run: uv run zizmor --min-severity=high --no-progress .github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
-name: "Lint"
+name: "CI"
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -9,20 +12,20 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
     - run: uv lock --check
-  lint-python:
+  lint-format-python:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
     - run: uv run ruff check
     - run: uv run ruff format --check
-  ts-typecheck:
+  typecheck-ts:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/ts-deps
     - run: pnpm typecheck
-  lint-ts:
+  lint-format-ts:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: "Lint"
+on:
+  pull_request:
+
+jobs:
+  check-uv-lock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/python-deps
+    - run: uv lock --check
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/python-deps
+    - run: uv run ruff check
+    - run: uv run ruff format --check
+  ts-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/ts-deps
+    - run: pnpm typecheck
+  lint-ts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/ts-deps
+    - run: pnpm oxlint
+    - run: pnpm biome check
+  lint-gha:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/python-deps
+    - run: uv run zizmor --min-severity=high .github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,6 @@ repos:
   - id: github-actions-lint
     name: github-actions-lint
     language: system
-    entry: uv run zizmor --min-severity=high .github
-    files: ^(\.github/workflows/.*.ya?ml|\.github/actions/.*.ya?ml)$
+    entry: uv run zizmor --min-severity=high --no-progress .github
+    files: (\.github/workflows/.*)|(action\.ya?ml)$
     pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,9 @@ repos:
     entry: pnpm biome check --fix
     types_or: [javascript, jsx, ts, tsx, json, css]
     pass_filenames: false
+  - id: github-actions-lint
+    name: github-actions-lint
+    language: system
+    entry: uv run zizmor --min-severity=high .github
+    files: ^(\.github/workflows/.*.ya?ml|\.github/actions/.*.ya?ml)$
+    pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.11.9",
+    "zizmor>=1.7.0",
 ]
 
 [tool.uv]

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# py-ts-exploration
+# py-ts-exploration - Github Actions
 
 This repo is for various explorations related to Python-backend/Typescript-frontend projects.
 
@@ -6,3 +6,6 @@ Each exploration is merged into `main` and categorized below.
 
 ## Layout and DevX
 - Initial layout, lint/formatting/typechecking tools: [pull/2](https://github.com/joecox/py-ts-exploration/pull/2)
+
+## CI
+- Github actions: [pull/3](https://github.com/joecox/py-ts-exploration/pull/3)

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -332,6 +333,7 @@ requires-dist = [{ name = "fastapi", extras = ["standard"], specifier = ">=0.115
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.11.9" },
+    { name = "zizmor", specifier = ">=1.7.0" },
 ]
 
 [[package]]
@@ -632,4 +634,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/92/97f0a6a6bf69ace4ada490c993d208533a993b08bb70073a54334b9a2977/zizmor-1.7.0.tar.gz", hash = "sha256:4f987f4b81ef740863db629391c55d1e7ad75723fc30325dfde63ab36537d6b0", size = 351214, upload-time = "2025-05-09T02:58:16.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/b7/b03e5e1ade3172a8f715d9e235d941d1555926dd23882ee88b224a8ed1a0/zizmor-1.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5973356825328fe7958366a0b02195710fb5ca9dc6dc48cfeebdd342929e59e8", size = 5583001, upload-time = "2025-05-09T02:58:09.57Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bb/d399592b9702c9df64f5a8622dd2c8ac4e5aa1c3bf3cf5c102745d4dddd7/zizmor-1.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:405fd2679e180d6399f06b7eef5063f4b9df611b9a60807bcd0bd9d47df9a9b0", size = 5285759, upload-time = "2025-05-09T02:58:07.676Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cc/509a1221d4f592ebd33d9046a05df2c87e45174b92d1fb885178e1ea70a6/zizmor-1.7.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:639d290d5074456542b6e5e275effe9565f88ffb24ef1088102bb7ca118ae7de", size = 5465419, upload-time = "2025-05-09T02:58:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/79/74/7d8a7c961cae7d668fe16743e387df1b2d61bd2cbe1aa51e2e7d54af227d/zizmor-1.7.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:8dd087a01ac713b8980af73f294c696ebcaafde38bade9a3773a3f792169c4d7", size = 5418353, upload-time = "2025-05-09T02:58:03.188Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e4/554d8db4e9edd3c53c3a721635592964fefc989744671437a1e8e1ed506c/zizmor-1.7.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a7dd9fa77086836d4fc270372a4fed6273bb92287585388ba258ccd9f59c044f", size = 5743098, upload-time = "2025-05-09T02:58:05.946Z" },
+    { url = "https://files.pythonhosted.org/packages/35/dd/b940fddcd618c430305eea34f5cf134fec6ebf0e38bc295ab622ac73bfd3/zizmor-1.7.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ca8a768db5dd267f985cf25515b99a4d893905fff05f4a45cecfc11dc84e4583", size = 5439824, upload-time = "2025-05-09T02:58:11.414Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/0639262c387fd967dfc0bb6b8e2e32fcc3efc117b39f85f3d517475261fb/zizmor-1.7.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8320f78cf19a65b3e81794a731d64a155c24bc8614347ed946b066e3411bb9de", size = 5428841, upload-time = "2025-05-09T02:58:12.968Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c1/f70581f79dc6ba4b738b7ccd69d56d92d4132271f2e37e004b060e7a5e98/zizmor-1.7.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:489ae4e9085d5aa80b9ae40e118f6e94a52af020cc17dc3942b51835ee02445b", size = 5821418, upload-time = "2025-05-09T02:58:14.57Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/48/cabdf25a86906a471d02f1251021c4451c182d3b7aae063e79a8e1d78dc5/zizmor-1.7.0-py3-none-win32.whl", hash = "sha256:e199bc49c1b2848ef28b083a3233eab7e289740d625b5e50b3e87de58cc06283", size = 4716050, upload-time = "2025-05-09T02:58:19.447Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2c/95259c0a430d908c5d17e0b863a5c2442f8e3b4a63f9085ffdc77cde8d2f/zizmor-1.7.0-py3-none-win_amd64.whl", hash = "sha256:6562fd039b4f40d94930bfb13e3a65e431fe76e85f87c6143d10c75e8a9c3187", size = 5300106, upload-time = "2025-05-09T02:58:17.834Z" },
 ]


### PR DESCRIPTION
## Github Actions CI

#### checks
- Adds all py/ts lint/format/typecheck as github actions ci jobs
- Establishes reusable python-deps and ts-deps actions which setup and cache deps

#### caching
The setup-uv, pnpm/action-setup, and setup-node actions include caching facilities.
- setup-uv caches the uv cache directory, which includes uv installed packages. The action [prunes the cache](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#disable-cache-pruning) from any pre-built wheels because downloading from pypi is faster than the cache, apparently.
- pnpm apparently works the same way ^, see [documentation](https://github.com/pnpm/action-setup/?tab=readme-ov-file#use-cache-to-reduce-installation-time)

#### zizmor
[Zizmor](https://docs.zizmor.sh/) runs security checks on github actions