### PR TITLE
Use dprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "CI"
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
 
 jobs:
@@ -12,29 +12,48 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
     - run: uv lock --check
-  lint-format-python:
+  lint-python:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
     - run: uv run ruff check
-    - run: uv run ruff format --check
-  typecheck-ts:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: ./.github/actions/ts-deps
-    - run: pnpm typecheck
-  lint-format-ts:
+  lint-ts:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/ts-deps
     - run: pnpm oxlint
-    - run: pnpm biome check
   lint-github-actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/python-deps
     - run: uv run zizmor --min-severity=high --no-progress .github
+
+  format-python:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/python-deps
+    - run: uv run ruff check --select I --fix
+    - run: uv run ruff format --check
+  format-ts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/ts-deps
+    - run: pnpm dprint check '**/*.{ts,tsx}'
+  format-other:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/ts-deps
+    - run: pnpm dprint check --exclude '**/*.{ts,tsx}'
+
+  typecheck-ts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ./.github/actions/ts-deps
+    - run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: ./.github/actions/ts-deps
-    - run: pnpm dprint check --exclude '**/*.{ts,tsx}'
+    - run: pnpm dprint check --excludes '**/*.{ts,tsx}'
 
   typecheck-ts:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,44 +15,53 @@ repos:
     entry: uv lock
     files: ^(uv\.lock|pyproject\.toml)$
     pass_filenames: false
-  - id: ruff-lint
-    name: ruff-lint
-    description: "Run the Ruff linter"
+
+  - id: lint-python
+    name: lint-python
+    description: "Lint python files using Ruff"
     language: system
     entry: uv run ruff check --fix
     types: [python]
     pass_filenames: false
-  - id: ruff-format
-    name: ruff-format
-    description: "Run the Ruff formatter"
+  - id: lint-ts
+    name: lint-ts
+    description: "Lint typescript using oxlint"
+    language: system
+    entry: pnpm oxlint --fix
+    types_or: [ts, tsx]
+    pass_filenames: false
+  - id: lint-github-actions
+    name: lint-github-actions
+    language: system
+    entry: uv run zizmor --min-severity=high --no-progress .github
+    files: (\.github/workflows/.*)|(action\.ya?ml)$
+    pass_filenames: false
+
+  - id: format-python
+    name: format-python
+    description: "Format python files using Ruff"
     language: system
     entry: uv run ruff format
     types: [python]
     pass_filenames: false
-  - id: ts-typecheck
-    name: ts-typecheck
-    description: "Typecheck Typescript across the entire project"
+  - id: format-ts
+    name: format-ts
+    description: "Format typescript using dprint"
+    language: system
+    entry: pnpm dprint fmt '**/*.{ts,tsx}'
+    types_or: [ts, tsx]
+    pass_filenames: false
+  - id: format-other
+    name: format-other
+    description: "Format other files (json, css, html, md, toml, docker) using dprint"
+    language: system
+    entry: pnpm dprint fmt --excludes '**/*.{ts,tsx}'
+    types_or: [json, css, html, markdown, toml, dockerfile]
+    pass_filenames: false
+  - id: typecheck-ts
+    name: typecheck-ts
+    description: "Typecheck typescript across the entire project"
     language: system
     entry: pnpm typecheck
-    types_or: [javascript, jsx, ts, tsx]
-    pass_filenames: false
-  - id: ts-lint
-    name: ts-lint
-    description: "Run the oxlint TS/JS linter"
-    language: system
-    entry: pnpm oxlint --fix
-    types_or: [javascript, jsx, ts, tsx]
-    pass_filenames: false
-  - id: ts-format
-    name: ts-format
-    description: "Run the Biome formatter"
-    language: system
-    entry: pnpm biome check --fix
-    types_or: [javascript, jsx, ts, tsx, json, css]
-    pass_filenames: false
-  - id: github-actions-lint
-    name: github-actions-lint
-    language: system
-    entry: uv run zizmor --min-severity=high --no-progress .github
-    files: (\.github/workflows/.*)|(action\.ya?ml)$
+    types_or: [ts, tsx]
     pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,10 +53,10 @@ repos:
     pass_filenames: false
   - id: format-other
     name: format-other
-    description: "Format other files (json, css, html, md, toml, docker) using dprint"
+    description: "Format other files (json, css, html, md, toml, docker, yaml) using dprint"
     language: system
     entry: pnpm dprint fmt --excludes '**/*.{ts,tsx}'
-    types_or: [json, css, html, markdown, toml, dockerfile]
+    types_or: [json, css, html, markdown, toml, dockerfile, yaml]
     pass_filenames: false
   - id: typecheck-ts
     name: typecheck-ts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["editorconfig.editorconfig", "charliermarsh.ruff"]
+  "recommendations": ["editorconfig.editorconfig", "charliermarsh.ruff", "dprint.dprint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,7 @@
   // Use the pnpm-installed typescript
   "typescript.tsdk": "./node_modules/typescript/lib",
   // Prompt users to select the workspace Typescript version
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+
+  "dprint.path": "./node_modules/.bin/dprint"
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,23 +3,23 @@
   "vcs": {
     "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": true
+    "useIgnoreFile": true,
   },
   "linter": {
     // Use oxlint for linting instead.
-    "enabled": false
+    "enabled": false,
   },
   "formatter": {
     "enabled": true,
-    "useEditorconfig": true
+    "useEditorconfig": true,
   },
   "organizeImports": {
-    "enabled": true
+    "enabled": true,
   },
   "json": {
     "parser": {
       "allowComments": true,
-      "allowTrailingCommas": true
-    }
-  }
+      "allowTrailingCommas": true,
+    },
+  },
 }

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -1,0 +1,32 @@
+{
+  "newLineKind": "lf",
+  "useTabs": false,
+  "indentWidth": 2,
+  "typescript": {
+    "quoteProps": "asNeeded",
+    "arrowFunction.useParentheses": "force",
+  },
+  "toml": {
+    "indentWidth": 4,
+  },
+  "malva": {
+  },
+  "markup": {
+  },
+  "yaml": {
+    "indentBlockSequenceInMap": false,
+  },
+  "excludes": [
+    "**/pnpm-lock.yaml",
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.95.3.wasm",
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.18.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/dockerfile-0.3.2.wasm",
+    "https://plugins.dprint.dev/g-plane/malva-v0.12.1.wasm",
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.20.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
+  ],
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.15.17",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^4.4.1",
+    "dprint": "^0.49.1",
     "oxlint": "^0.16.10",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
-      '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
       '@types/node':
         specifier: ^22.15.17
         version: 22.15.17
@@ -30,6 +27,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.4.1(vite@6.3.5(@types/node@22.15.17))
+      dprint:
+        specifier: ^0.49.1
+        version: 0.49.1
       oxlint:
         specifier: ^0.16.10
         version: 0.16.10
@@ -125,56 +125,48 @@ packages:
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
-    engines: {node: '>=14.21.3'}
-    hasBin: true
-
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/darwin-arm64@0.49.1':
+    resolution: {integrity: sha512-ib6KcJWo/M5RJWXOQKhP664FG1hAvG7nrbkh+j8n+oXdzmbyDdXTP+zW+aM3/sIQUkGaZky1xy1j2VeScMEEHQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/darwin-x64@0.49.1':
+    resolution: {integrity: sha512-vIVgnYxV7YYa1d6Uyz707RbgB9rwefGPam+rzaueFNPQjdOxPOTQDuMEJDS+Z3BlI00MfeoupIfIUGsXoM4dpQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/linux-arm64-glibc@0.49.1':
+    resolution: {integrity: sha512-ZeIh6qMPWLBBifDtU0XadpK36b4WoaTqCOt0rWKfoTjq1RAt78EgqETWp43Dbr6et/HvTgYdoWF0ZNEu2FJFFA==}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/linux-arm64-musl@0.49.1':
+    resolution: {integrity: sha512-/nuRyx+TykN6MqhlSCRs/t3o1XXlikiwTc9emWdzMeLGllYvJrcht9gRJ1/q1SqwCFhzgnD9H7roxxfji1tc+Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/linux-riscv64-glibc@0.49.1':
+    resolution: {integrity: sha512-RHBqrnvGO+xW4Oh0QuToBqWtkXMcfjqa1TqbBFF03yopFzZA2oRKX83PhjTWgd/IglaOns0BgmaLJy/JBSxOfQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@dprint/linux-x64-glibc@0.49.1':
+    resolution: {integrity: sha512-MjFE894mIQXOKBencuakKyzAI4KcDe/p0Y9lRp9YSw/FneR4QWH9VBH90h8fRxcIlWMArjFFJJAtsBnn5qgxeg==}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/linux-x64-musl@0.49.1':
+    resolution: {integrity: sha512-CvGBWOksHgrL1uzYqtPFvZz0+E82BzgoCIEHJeuYaveEn37qWZS5jqoCm/vz6BfoivE1dVuyyOT78Begj9KxkQ==}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/win32-arm64@0.49.1':
+    resolution: {integrity: sha512-gQa4s82lMcXjfdxjWBQun6IJlXdPZZaIj2/2cqXWVEOYPKxAZ/JvGzt2pPG+i73h9KHjNLIV8M9ckqEH3oHufg==}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
-    engines: {node: '>=14.21.3'}
+  '@dprint/win32-x64@0.49.1':
+    resolution: {integrity: sha512-nPU6+hoVze5JJlgET7woYWElBw0IUaB/9XKTaglknQuUUfsmD75D9pkgJTxdIxl9Bg/i5O7c9wb3Nj4XNiTIfw==}
     cpu: [x64]
     os: [win32]
 
@@ -541,6 +533,10 @@ packages:
       supports-color:
         optional: true
 
+  dprint@0.49.1:
+    resolution: {integrity: sha512-pO9XH79SyXybj2Vhc9ITZMEI8cJkdlQQRoD8oEfPH6Jjpp/7WX5kIgECVd3DBOjjAdCSiW6R47v3gJBx/qZVkw==}
+    hasBin: true
+
   electron-to-chromium@1.5.151:
     resolution: {integrity: sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==}
 
@@ -824,39 +820,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@biomejs/biome@1.9.4':
-    optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
-
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@dprint/darwin-arm64@0.49.1':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@dprint/darwin-x64@0.49.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@dprint/linux-arm64-glibc@0.49.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@dprint/linux-arm64-musl@0.49.1':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@dprint/linux-riscv64-glibc@0.49.1':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@dprint/linux-x64-glibc@0.49.1':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@dprint/linux-x64-musl@0.49.1':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@dprint/win32-arm64@0.49.1':
+    optional: true
+
+  '@dprint/win32-x64@0.49.1':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.4':
@@ -1097,6 +1085,18 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  dprint@0.49.1:
+    optionalDependencies:
+      '@dprint/darwin-arm64': 0.49.1
+      '@dprint/darwin-x64': 0.49.1
+      '@dprint/linux-arm64-glibc': 0.49.1
+      '@dprint/linux-arm64-musl': 0.49.1
+      '@dprint/linux-riscv64-glibc': 0.49.1
+      '@dprint/linux-x64-glibc': 0.49.1
+      '@dprint/linux-x64-musl': 0.49.1
+      '@dprint/win32-arm64': 0.49.1
+      '@dprint/win32-x64': 0.49.1
 
   electron-to-chromium@1.5.151: {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,9 @@ extend-select = [
     # https://docs.astral.sh/ruff/rules/redirected-noqa/
     # https://docs.astral.sh/ruff/rules/invalid-rule-code/
     # Prevent issues with noqa directives, like blanket directives or invalid codes
-    "PGH004", "RUF100", "RUF101",
+    "PGH004",
+    "RUF100",
+    "RUF101",
     # https://docs.astral.sh/ruff/rules/invalid-pyproject-toml/
     # Prevent invalid pyproject.toml
     "RUF200",

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@ Each exploration is merged into `main` and categorized below.
 ## Tooling and DevX
 
 - lint/formatting/typechecking tools: [pull/2](https://github.com/joecox/py-ts-exploration/pull/2)
-- use dprint: [pull/x]
+- use dprint: [pull/7](https://github.com/joecox/py-ts-exploration/pull/7)
 
 ## CI
 
 - Github actions: [pull/3](https://github.com/joecox/py-ts-exploration/pull/3)
-- separate lint/format steps: [pull/x]
+- separate lint/format steps: [pull/7](https://github.com/joecox/py-ts-exploration/pull/7)

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,12 @@ This repo is for various explorations related to Python-backend/Typescript-front
 
 Each exploration is merged into `main` and categorized below.
 
-## Layout and DevX
-- Initial layout, lint/formatting/typechecking tools: [pull/2](https://github.com/joecox/py-ts-exploration/pull/2)
+## Tooling and DevX
+
+- lint/formatting/typechecking tools: [pull/2](https://github.com/joecox/py-ts-exploration/pull/2)
+- use dprint: [pull/x]
 
 ## CI
+
 - Github actions: [pull/3](https://github.com/joecox/py-ts-exploration/pull/3)
+- separate lint/format steps: [pull/x]


### PR DESCRIPTION
This PR:
- Uses dprint for all formatting, aside from python

We _could_ use dprint for all formatting, include python, since they ship with a Ruff wasm plugin. But it just seemed pointless to lose a little perf via a wasm build when we already have Ruff natively installed, just to unify all formatting into one tool.
