### PR TITLE
Update pydantic settings usage

### DIFF
--- a/backend/lib/other.py
+++ b/backend/lib/other.py
@@ -1,2 +1,0 @@
-def other():
-    return "foo"

--- a/backend/lib/settings/__init__.py
+++ b/backend/lib/settings/__init__.py
@@ -1,14 +1,19 @@
 import os
+from functools import cache
 from typing import Literal
 
 from pydantic import PostgresDsn
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(frozen=True)
+
     environment: Literal["local", "test", "prod"]
     pg_dsn: PostgresDsn
 
 
-env = os.environ.get("ENV")
-settings = Settings(_env_file=f".env.{env}", environment=env)
+@cache
+def get_settings():
+    env = os.environ.get("ENV")
+    return Settings(_env_file=f".env.{env}", environment=env)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,12 @@
-from fastapi import FastAPI
-
-from lib.other import other
-from lib.settings import settings
-
-app = FastAPI()
+from lib.settings import get_settings
+from server import app
 
 
 @app.get("/")
 def root():
-    return {"hello": other()}
+    return {"hello": "world"}
 
 
 @app.get("/settings")
-def get_settings():
-    return settings
+def settings():
+    return get_settings()

--- a/backend/server/__init__.py
+++ b/backend/server/__init__.py
@@ -1,0 +1,17 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from lib.settings import get_settings
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    # startup
+    # 1. attempt to load settings from env
+    get_settings()
+    yield
+    # shutdown
+
+
+app = FastAPI(lifespan=lifespan)

--- a/readme.md
+++ b/readme.md
@@ -14,3 +14,7 @@ Each exploration is merged into `main` and categorized below.
 
 - Github actions: [pull/3](https://github.com/joecox/py-ts-exploration/pull/3)
 - separate lint/format steps: [pull/7](https://github.com/joecox/py-ts-exploration/pull/7)
+
+## Env
+
+- pydantic settings: [pull/6](https://github.com/joecox/py-ts-exploration/pull/6), [pull/10](https://github.com/joecox/py-ts-exploration/pull/10)


### PR DESCRIPTION
This PR updates pydantic-settings to be used in a cached function. This allows settings to be loaded explicitly during server startup, instead of implicitly by importing the file, which felt janky.